### PR TITLE
fix: reduce high CPU usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,13 @@ func main() {
 				processLine(scanner.Text())
 			}
 		}
+		
+		if err := scanner.Err(); err != nil {
+			log.Errorf("Error reading from file: %s", err)
+			time.Sleep(1 * time.Second)
+		} else {
+			time.Sleep(200 * time.Millisecond)
+		}
 	}()
 
 	// Metrics server


### PR DESCRIPTION
Fixed high CPU usage caused by a busy-wait loop reading lines from a JSONL file without delay. This loop was consuming up to 500% CPU by keeping it constantly occupied.